### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For technical details on how to compile the extension, add test cases etc, visit
 [![ScreenShot](http://dhruvaray.github.io/spa-eye/site/img/video.png)](http://youtu.be/tEIxBqjR1Cc)
 
 
-###Download
+### Download
 Download from the Mozilla store  : https://addons.mozilla.org/en-US/firefox/addon/Backbone-Eye/
 
 If Backbone-Eye is useful in your work, do show your appreciation and encouragement by starring this repo or giving a review on the Mozilla store!
@@ -24,7 +24,7 @@ If Backbone-Eye is useful in your work, do show your appreciation and encouragem
 ![Screenshot](http://dhruvaray.github.io/spa-eye/site/img/composite.gif)
 
 
-###Thanks
+### Thanks
 * Backbone Eye [contributors](https://github.com/dhruvaray/spa-eye/graphs/contributors)!
 * The awesome folks @ the [Firebug forum](https://groups.google.com/forum/#!forum/firebug).
 * The awesome [Firebug](https://github.com/firebug/firebug) code. Even better than the available documentation!
@@ -32,8 +32,8 @@ If Backbone-Eye is useful in your work, do show your appreciation and encouragem
 * [icoMoon - free version](http://icomoon.io/#icons) for our extension icons.
 * The [todomvc](http://todomvc.com/) site for providing (sexy looking) reference examples and is also used as a reference example in our documentation.
 
-###License
+### License
 [Simplified BSD 2-Clause](https://github.com/dhruvaray/spa-eye/blob/master/extension/license.txt)
 
-###Usage
+### Usage
 [Usage Stats](https://addons.mozilla.org/en-US/firefox/addon/Backbone-Eye/statistics/?last=30)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
